### PR TITLE
Fix markup warnings causing details popups not to show.

### DIFF
--- a/src/gracer.py
+++ b/src/gracer.py
@@ -249,7 +249,9 @@ class GracerCompletionProvider(GObject.Object, GtkSource.CompletionProvider):
 
         #TODO: add completion for type (ex. add extra brackets for functions)
         for _text, _type, _path, _line in self.racer.get_matches(document):
-            proposals.append(GtkSource.CompletionItem.new(_text, _text, self.get_icon_for_type(_type), _line))
+            proposals.append(GtkSource.CompletionItem.new(
+                _text, _text, self.get_icon_for_type(_type),
+                _line.replace('&', '&amp;').replace('<', '&lt;')))
 
         context.add_proposals(self, proposals, True)
 


### PR DESCRIPTION
For example:

```
(gedit:23934): Gtk-WARNING **: Failed to set text 'Option<u16>' from markup due to error parsing markup: Error on line 1 char 28: Element 'markup' was closed, but the currently open element is 'u16'
```

I have no idea what I’m doing. I’m only guessing from the warning message
that this string is interpreted in XML-like syntax.

I haven’t tested the `&` → `&amp;` part, I don’t know if `&` occurs in Rust types.
