### PR TITLE
mkdir -p will make the whole path when needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A rust code completion plugin for gedit. Built with the Rust auto completion too
 
 Instead of downloading you can just clone the project to your plugin path:
 ```
-$ mkdir ~/.local/share/gedit/plugins
+$ mkdir -p ~/.local/share/gedit/plugins
 $ git clone https://github.com/isamert/gracer.git
 ```
 For updating:


### PR DESCRIPTION
I didn't have a ~/.local/share/gedit folder at all.

From the mkdir man page:
-p, --parents  no error if existing, make parent directories as needed
